### PR TITLE
Cloud Tasks の Header 検証に便利な機能を追加した

### DIFF
--- a/auth/header.go
+++ b/auth/header.go
@@ -1,0 +1,11 @@
+package auth
+
+import "net/http"
+
+// IsGCPInternal is Request が GCP 内部の Component から送られてきたかを返す
+//
+// 該当するもの
+// Cloud Tasks App Engine Task
+func IsGCPInternal(r *http.Request) bool {
+	return r.Header.Get("X-Google-Internal-Skipadmincheck") == "true"
+}

--- a/auth/header_test.go
+++ b/auth/header_test.go
@@ -1,0 +1,23 @@
+package auth_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sinmetalcraft/gcpbox/auth"
+)
+
+func TestIsGCPInternal(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.IsGCPInternal(r) {
+		t.Errorf("want IsGCPInternal() is false...")
+	}
+
+	r.Header.Set("X-Google-Internal-Skipadmincheck", "true")
+	if !auth.IsGCPInternal(r) {
+		t.Errorf("want IsGCPInternal() is true...")
+	}
+}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// JWTPayload is JWT Payload
+type JWTPayload struct {
+	Audience        string `json:"aud"`            // JWTを受け取る予定の対象者 example:https://gcpboxtest-73zry4yfvq-an.a.run.app/cloudtasks/run/json-post-task
+	AuthorizedParty string `json:"azp"`            // 認可された対象者 example:102542703233071533897
+	Email           string `json:"email"`          // JWT発行者のEmail example:sinmetal-ci@appspot.gserviceaccount.com
+	EmailVerified   bool   `json:"email_verified"` // メールアドレスが検証済みか
+	Expires         int    `json:"exp"`            // 有効期限(EpochTime seconds) example:1602514972
+	IssuedAt        int    `json:"iat"`            // 発行日時(EpochTime seconds) example:1602511372
+	Issuer          string `json:"iss"`            // 発行者 (issuer) example:https://accounts.google.com
+	Subject         string `json:"sub"`            // UserID example:102542703233071533897
+}
+
+// ParseJWTPayload is JWT全体から の Payload を抜き出して返す
+func ParseJWTPayload(jwt string) (*JWTPayload, error) {
+	list := strings.Split(jwt, ".")
+	if len(list) != 3 {
+		return nil, fmt.Errorf("invalid JWT format")
+	}
+
+	var payload *JWTPayload
+	r := base64.NewDecoder(base64.RawStdEncoding, strings.NewReader(list[1]))
+	if err := json.NewDecoder(r).Decode(&payload); err != nil {
+		return nil, xerrors.Errorf("invalid JWT :%w", err)
+	}
+	return payload, nil
+}

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -1,0 +1,38 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/sinmetalcraft/gcpbox/auth"
+)
+
+func TestParseJWTPayload(t *testing.T) {
+	payload, err := auth.ParseJWTPayload("Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjdkYTc4NjNlODYzN2Q2NjliYzJhMTI2MjJjZWRlMmE4ODEzZDExYjEiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2djcGJveHRlc3QtNzN6cnk0eWZ2cS1hbi5hLnJ1bi5hcHAvY2xvdWR0YXNrcy9ydW4vanNvbi1wb3N0LXRhc2siLCJhenAiOiIxMDI1NDI3MDMyMzMwNzE1MzM4OTciLCJlbWFpbCI6InNpbm1ldGFsLWNpQGFwcHNwb3QuZ3NlcnZpY2VhY2NvdW50LmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJleHAiOjE2MDI2Njc0MDQsImlhdCI6MTYwMjY2MzgwNCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyNTQyNzAzMjMzMDcxNTMzODk3In0.署名")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, g := "https://gcpboxtest-73zry4yfvq-an.a.run.app/cloudtasks/run/json-post-task", payload.Audience; e != g {
+		t.Errorf("want Audience %s but got %s", e, g)
+	}
+	if e, g := "102542703233071533897", payload.AuthorizedParty; e != g {
+		t.Errorf("want AuthorizedParty %s but got %s", e, g)
+	}
+	if e, g := "sinmetal-ci@appspot.gserviceaccount.com", payload.Email; e != g {
+		t.Errorf("want Email %s but got %s", e, g)
+	}
+	if e, g := true, payload.EmailVerified; e != g {
+		t.Errorf("want EmailVerified %t but got %t", e, g)
+	}
+	if e, g := 1602667404, payload.Expires; e != g {
+		t.Errorf("want Expires %d but got %d", e, g)
+	}
+	if e, g := 1602663804, payload.IssuedAt; e != g {
+		t.Errorf("want IssuedAt %d but got %d", e, g)
+	}
+	if e, g := "https://accounts.google.com", payload.Issuer; e != g {
+		t.Errorf("want Issuer %s but got %s", e, g)
+	}
+	if e, g := "102542703233071533897", payload.Subject; e != g {
+		t.Errorf("want Subject %s but got %s", e, g)
+	}
+}

--- a/cloudtasks/appengine/validator.go
+++ b/cloudtasks/appengine/validator.go
@@ -1,0 +1,29 @@
+package appengine
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/sinmetalcraft/gcpbox/auth"
+	"google.golang.org/api/idtoken"
+)
+
+// ValidateJWTFromHttpTargetTask is Http Target Task を App Engine で受けた時の JWT の検証を行う
+// App Engine Task の場合は JWT はくっついていないので、 auth.IsGCPInternal() をチェックすることになる
+func ValidateJWTFromHttpTargetTask(ctx context.Context, r *http.Request, projectNumber string, projectID string) (*auth.JWTPayload, error) {
+	iapJWT := r.Header.Get("X-Goog-IAP-JWT-Assertion")
+	aud := fmt.Sprintf("/projects/%s/apps/%s", projectNumber, projectID)
+
+	_, err := idtoken.Validate(ctx, iapJWT, aud)
+	if err != nil {
+		return nil, fmt.Errorf("idtoken.Validate: %v", err)
+	}
+
+	payload, err := auth.ParseJWTPayload(iapJWT)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}

--- a/cloudtasks/validator.go
+++ b/cloudtasks/validator.go
@@ -1,0 +1,34 @@
+package cloudtasks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/sinmetalcraft/gcpbox/auth"
+	"google.golang.org/api/idtoken"
+)
+
+// ValidateJWT is JWT を検証して、 Cloud Run Invoker を持った Service Account からの Request なのかを確かめる
+// Cloud Run Invoker の場合は Authorization Header に JWT が入って Request が飛んでくる
+// audience には Cloud Task からの Request の URL を指定する
+func ValidateJWTFromInvoker(ctx context.Context, r *http.Request, audience string) (*auth.JWTPayload, error) {
+	authzHeader := r.Header.Get("Authorization")
+	tokens := strings.Split(authzHeader, " ")
+	if len(tokens) < 1 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+	authzHeader = tokens[1]
+
+	_, err := idtoken.Validate(ctx, authzHeader, audience)
+	if err != nil {
+		return nil, fmt.Errorf("failed idtoken.Validate: %v", err)
+	}
+	payload, err := auth.ParseJWTPayload(authzHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}


### PR DESCRIPTION
App Engine Task と HTTP Target Task で Header の内容が違ったり、受けるのが Cloud Run なのか、 IAP 介した App Engine なのかとかで、結構内容が変わるので、整理して適当に取れる機能を作った

close #2