### PR TITLE
Cloud Resource Manager IAM Check inherit options

### DIFF
--- a/cloudresourcemanager/v3/options.go
+++ b/cloudresourcemanager/v3/options.go
@@ -1,9 +1,10 @@
 package cloudresourcemanager
 
 type existsMemberInheritOption struct {
-	roles    []string
-	topNodes []*ResourceID
-	step     int
+	roles         []string
+	topNodes      []*ResourceID
+	censoredNodes []*ResourceID
+	step          int
 }
 
 // ExistsMemberInheritOptions is ExistsMemberInGCPProjectWithInherit に利用する options
@@ -27,6 +28,13 @@ func WithTopNode(resource *ResourceID) ExistsMemberInheritOptions {
 func WithTopNodes(resources []*ResourceID) ExistsMemberInheritOptions {
 	return func(ops *existsMemberInheritOption) {
 		ops.topNodes = append(ops.topNodes, resources...)
+	}
+}
+
+// WithCensoredNodes is 指定したResourceが現れたら、そのResourceの権限はチェックせずに遡るのをやめる
+func WithCensoredNodes(resources []*ResourceID) ExistsMemberInheritOptions {
+	return func(ops *existsMemberInheritOption) {
+		ops.censoredNodes = append(ops.censoredNodes, resources...)
 	}
 }
 

--- a/cloudresourcemanager/v3/options.go
+++ b/cloudresourcemanager/v3/options.go
@@ -1,9 +1,9 @@
 package cloudresourcemanager
 
 type existsMemberInheritOption struct {
-	roles   []string
-	topNode *ResourceID
-	step    int
+	roles    []string
+	topNodes []*ResourceID
+	step     int
 }
 
 // ExistsMemberInheritOptions is ExistsMemberInGCPProjectWithInherit に利用する options
@@ -19,7 +19,14 @@ func WithRolesHaveOne(roles ...string) ExistsMemberInheritOptions {
 // WithTopNode is 階層を遡る時にそこまでいったらやめるポイントを指定する
 func WithTopNode(resource *ResourceID) ExistsMemberInheritOptions {
 	return func(ops *existsMemberInheritOption) {
-		ops.topNode = resource
+		ops.topNodes = append(ops.topNodes, resource)
+	}
+}
+
+// WithTopNodes is 階層を遡る時にそこまでいったらやめるポイントを指定する
+func WithTopNodes(resources []*ResourceID) ExistsMemberInheritOptions {
+	return func(ops *existsMemberInheritOption) {
+		ops.topNodes = append(ops.topNodes, resources...)
 	}
 }
 

--- a/cloudresourcemanager/v3/resourcemanager_service.go
+++ b/cloudresourcemanager/v3/resourcemanager_service.go
@@ -133,7 +133,7 @@ func (s *ResourceManagerService) ExistsMemberInGCPProjectWithInherit(ctx context
 	var rets []*ExistsMemberCheckResult
 	project, err := s.GetProject(ctx, projectID)
 	if err != nil {
-		return false, nil, xerrors.Errorf("failed get project: projectID=%s, email=%s, roles=%+v : %w", projectID, email, opt.roles, err)
+		return false, rets, xerrors.Errorf("failed get project: projectID=%s, email=%s, roles=%+v : %w", projectID, email, opt.roles, err)
 	}
 	if project.Parent == "" {
 		return false, rets, nil
@@ -144,6 +144,10 @@ func (s *ResourceManagerService) ExistsMemberInGCPProjectWithInherit(ctx context
 		return false, nil, xerrors.Errorf("failed ConvertResourceID. parent=%s, projectID=%s, email=%s, roles=%+v : %w", project.Parent, projectID, email, opt.roles, err)
 	}
 	for {
+		if s.findResource(opt.censoredNodes, parent) {
+			return false, rets, nil
+		}
+
 		var exists bool
 		var err error
 		switch parent.Type {

--- a/cloudresourcemanager/v3/resourcemanager_service.go
+++ b/cloudresourcemanager/v3/resourcemanager_service.go
@@ -107,7 +107,6 @@ func (s *ResourceManagerService) ExistsMemberInGCPProject(ctx context.Context, p
 // ExistsMemberCheckResult is 上位階層のIAMをチェックした履歴
 type ExistsMemberCheckResult struct {
 	Resource     *ResourceID
-	Parent       *ResourceID
 	Exists       bool
 	TopNode      bool
 	CensoredNode bool

--- a/cloudresourcemanager/v3/resourcemanager_service.go
+++ b/cloudresourcemanager/v3/resourcemanager_service.go
@@ -177,7 +177,7 @@ func (s *ResourceManagerService) ExistsMemberInGCPProjectWithInherit(ctx context
 		}
 		switch parent.Type {
 		case "folder":
-			if cmp.Equal(parent, opt.topNode) {
+			if s.findResource(opt.topNodes, parent) {
 				return false, rets, nil
 			}
 
@@ -199,6 +199,15 @@ func (s *ResourceManagerService) ExistsMemberInGCPProjectWithInherit(ctx context
 			return false, rets, fmt.Errorf("%s is unsupported resource type", parent.Type)
 		}
 	}
+}
+
+func (s *ResourceManagerService) findResource(resources []*ResourceID, resource *ResourceID) bool {
+	for _, r := range resources {
+		if cmp.Equal(r, resource) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *ResourceManagerService) existsMemberInGCPProject(ctx context.Context, projectID string, email string, roles ...string) (bool, error) {

--- a/cloudresourcemanager/v3/resourcemanager_service_test.go
+++ b/cloudresourcemanager/v3/resourcemanager_service_test.go
@@ -224,7 +224,7 @@ func TestResourceManagerService_ExistsMemberInGCPProjectWithInherit(t *testing.T
 		{"Projectが存在して権限を持っていない", "gcpug-public-spanner", "hoge@example.com", nil, false, crmbox.ErrPermissionDenied},
 		{"Projectが存在していない", "adoi893lda3fd1", "hoge@example.com", nil, false, crmbox.ErrPermissionDenied},
 		{"Projectが存在して、Projectが所属している祖父のFolderの権限を持っているメンバーが存在しているが、step数的に届かない", "gcpbox-ci", "gcpbox-iam-test-1@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithStep(1)}, false, nil},
-		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているがOrganizationまで見に行かない", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithTopNode(&crmbox.ResourceID{Type: "folder", ID: "484650900491"})}, false, nil},
+		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているがOrganizationまで見に行かない", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithTopNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "folder", ID: "484650900491"}})}, false, nil},
 		{"Projectが存在して権限を持っており、メンバーが存在しているが指定されたRoleではない", "sinmetal-ci", "sinmetal@sinmetalcraft.jp", []crmbox.ExistsMemberInheritOptions{crmbox.WithRolesHaveOne("roles/Owner")}, false, nil},
 	}
 

--- a/cloudresourcemanager/v3/resourcemanager_service_test.go
+++ b/cloudresourcemanager/v3/resourcemanager_service_test.go
@@ -225,7 +225,7 @@ func TestResourceManagerService_ExistsMemberInGCPProjectWithInherit(t *testing.T
 		{"Projectが存在していない", "adoi893lda3fd1", "hoge@example.com", nil, false, crmbox.ErrPermissionDenied},
 		{"Projectが存在して、Projectが所属している祖父のFolderの権限を持っているメンバーが存在しているが、step数的に届かない", "gcpbox-ci", "gcpbox-iam-test-1@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithStep(1)}, false, nil},
 		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているが、手前のfolderをtopで終わる", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithTopNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "folder", ID: "484650900491"}})}, false, nil},
-		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているが、Organizationの権限チェックは打ち切る", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithCensoredNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "organization", ID: "956776603191"}})}, false, nil},
+		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているが、Organizationの権限チェックは打ち切る", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithCensoredNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "organization", ID: sinmetalcraftJPOrg}})}, false, nil},
 		{"Projectが存在して権限を持っており、メンバーが存在しているが指定されたRoleではない", "sinmetal-ci", "sinmetal@sinmetalcraft.jp", []crmbox.ExistsMemberInheritOptions{crmbox.WithRolesHaveOne("roles/Owner")}, false, nil},
 	}
 

--- a/cloudresourcemanager/v3/resourcemanager_service_test.go
+++ b/cloudresourcemanager/v3/resourcemanager_service_test.go
@@ -224,7 +224,8 @@ func TestResourceManagerService_ExistsMemberInGCPProjectWithInherit(t *testing.T
 		{"Projectが存在して権限を持っていない", "gcpug-public-spanner", "hoge@example.com", nil, false, crmbox.ErrPermissionDenied},
 		{"Projectが存在していない", "adoi893lda3fd1", "hoge@example.com", nil, false, crmbox.ErrPermissionDenied},
 		{"Projectが存在して、Projectが所属している祖父のFolderの権限を持っているメンバーが存在しているが、step数的に届かない", "gcpbox-ci", "gcpbox-iam-test-1@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithStep(1)}, false, nil},
-		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているがOrganizationまで見に行かない", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithTopNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "folder", ID: "484650900491"}})}, false, nil},
+		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているが、手前のfolderをtopで終わる", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithTopNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "folder", ID: "484650900491"}})}, false, nil},
+		{"Projectが存在して、Projectが所属しているOrganizationの権限を持っているメンバーが存在しているが、Organizationの権限チェックは打ち切る", "gcpbox-ci", "gcpbox-iam-test-2@sinmetal-ci.iam.gserviceaccount.com", []crmbox.ExistsMemberInheritOptions{crmbox.WithCensoredNodes([]*crmbox.ResourceID{&crmbox.ResourceID{Type: "organization", ID: "956776603191"}})}, false, nil},
 		{"Projectが存在して権限を持っており、メンバーが存在しているが指定されたRoleではない", "sinmetal-ci", "sinmetal@sinmetalcraft.jp", []crmbox.ExistsMemberInheritOptions{crmbox.WithRolesHaveOne("roles/Owner")}, false, nil},
 	}
 


### PR DESCRIPTION
## TopNodeを複数指定できるようにした

Orgの階層が複雑だと、色んな枝があり、どこまで遡るかの指定も複数になる

## CensoredNodesを追加

指定したNodeが現れたら、そのNodeのIAMはチェックせずに終わるオプション
Orgの直下にいるProjectの場合、AppがOrgの権限を持っていなければ、TopNodeで止まれる場所がないので、見えたら、終わるオプションを追加した